### PR TITLE
Add Safari Download Support to WebhistoryMacos

### DIFF
--- a/templates/WebhistoryMacos.template
+++ b/templates/WebhistoryMacos.template
@@ -122,6 +122,18 @@ sources:
                 )
             })
 
+      LET SafariDownloadFile <= SELECT * FROM foreach(
+            row=target_users,
+            query={
+                SELECT User, OSPath, Mtime
+                FROM glob(
+                    root=HomeDirectory,
+                    globs=[
+                        '/Library/Safari/Downloads.plist'
+                    ]
+                )
+            })
+
       -- run first pass to extract any DomainRegex hits
       LET hits = SELECT BrowserArtifact,
             parse_string_with_regex(string=VisitedURL, regex='^.+://([^:/\\s]+)').g1 as Domain,
@@ -267,6 +279,33 @@ sources:
                           query=SafariURL)
                         ORDER BY Visit_Date DESC
                       })
+            },
+            safaridownload = {
+                SELECT "Safari Download" as BrowserArtifact,
+                    DownloadURL as VisitedURL,
+                    dict(
+                        User=User,
+                        Download_Date=Download_Date,
+                        Download_Date_Finished=Download_Date_Finished,
+                        DownloadPath=DownloadPath,
+                        DownloadURL=DownloadURL,
+                        OSPath=OSPath
+                    ) as ArtifactData
+                FROM foreach(row=SafariDownloadFile,
+                    query={
+                    SELECT *
+                    FROM foreach(row=plist(file=OSPath).DownloadHistory,
+                       query={
+                       SELECT User,
+                       DownloadEntryDateAddedKey AS Download_Date,
+                       DownloadEntryDateFinishedKey AS Download_Date_Finished,
+                       DownloadEntryPath AS DownloadPath,
+                       DownloadEntryURL AS DownloadURL,
+                       OSPath
+                       FROM scope()
+                       ORDER BY Download_Date DESC
+                       })
+                  })
             })
         WHERE Domain =~ join(array=IOCs.DomainRegex,sep='|')
 


### PR DESCRIPTION
This is a continuation of #94 and #97 and completes coverage of macOS browsing history by adding Downloads.plist parsing support. Sadly by default Safari removes download history after 1 day but if defaults are changed to keep download history or the timing lines up might still be useful for us. Thanks @Seeps for the inspiration based on MacOS.Applications.Safari.Downloads.

Unrelated to this pull request when I was doing testing I noticed errors on some of the MFT tests when running the GitHub Runner ZipVQL.yaml. This may cause deployment issues when this pull request is merged so thought I would give you a heads up. 